### PR TITLE
Explain Financial Type data type

### DIFF
--- a/docs/common-workflows/importing-data-into-civicrm.md
+++ b/docs/common-workflows/importing-data-into-civicrm.md
@@ -394,15 +394,15 @@ the following fields:
 -   Contact Id or External Identifier or all the fields used in your
     Unsupervised Duplicate Matching rule (to match to an existing
     contact)
--   Financial Type
--   Total Amount
+-   Financial Type (to match text of an existing type, e.g. Campaign Contribution, Donation, Event Fee, Member Dues)
+-   Total Amount
 
 If you want to **update existing contributions,** your CSV file must
 include at least the following fields:
 
 -   Transaction ID or Invoice ID or Payment ID (to match to an existing
     contribution)
--   Financial Type
+-   Financial Type (to match text of an existing type, e.g. Campaign Contribution, Donation, Event Fee, Member Dues)
 -   Total Amount
 
 You can use also use **update existing contributions** to import new or


### PR DESCRIPTION
The import data for Financial Type should match an existing text such as Campaign Contribution, Donation, Event Fee, or Member Dues, and not their index number. Perhaps there should be a document detailing the mapping for importing data, if there isn't one already?